### PR TITLE
chore: add session knowledge base

### DIFF
--- a/.claude/knowledge/REGISTRY.md
+++ b/.claude/knowledge/REGISTRY.md
@@ -1,0 +1,11 @@
+# Knowledge Registry
+
+Durable, reusable insights extracted from work sessions. One line per entry; detail lives in the linked file.
+
+## Patterns
+- K-PAT-001 [2026-06-23] Fix GitHub language stats with .gitattributes — mark compiled/vendored files so linguist ignores them  (.claude/knowledge/patterns/K-PAT-001-gitattributes-linguist.md)
+
+## Pitfalls
+- K-PIT-001 [2026-06-23] node-sass@4 native build fails on modern Node — whole install aborts; use `--ignore-scripts` then migrate to Dart sass  (.claude/knowledge/pitfalls/K-PIT-001-node-sass-modern-node.md)
+- K-PIT-002 [2026-06-23] react-scripts 3.x won't start on Node 17+ — needs `NODE_OPTIONS=--openssl-legacy-provider`  (.claude/knowledge/pitfalls/K-PIT-002-react-scripts-openssl.md)
+- K-PIT-003 [2026-06-23] Don't bake reputation framing or secret-shaped text into committed docs — scrub before committing  (.claude/knowledge/pitfalls/K-PIT-003-reputation-framing-in-committed-docs.md)

--- a/.claude/knowledge/patterns/K-PAT-001-gitattributes-linguist.md
+++ b/.claude/knowledge/patterns/K-PAT-001-gitattributes-linguist.md
@@ -1,0 +1,25 @@
+# K-PAT-001: Fix GitHub language stats with .gitattributes linguist flags
+
+**Category:** Pattern
+**Created:** 2026-06-23
+**Tags:** github, linguist, gitattributes, repo-hygiene, presentation
+
+## Context
+This repo commits a compiled `public/css/style.css` (build artifact of the SCSS). GitHub's linguist counts it, so the repo's language bar misrepresents it as a CSS project rather than JS/SCSS.
+
+## Insight
+Mark generated and vendored files in `.gitattributes` so GitHub excludes them from the language breakdown — without deleting the files.
+
+## Why it matters
+The language bar is the first thing visitors see on a repo. Accurate stats make a project read as what it actually is.
+
+## Example
+```gitattributes
+* text=auto eol=lf
+public/css/style.css   linguist-generated=true
+public/css/icon-font.css linguist-vendored=true
+package-lock.json      linguist-generated=true
+```
+
+## Application
+Any repo that commits build output, minified bundles, or large vendored files and whose GitHub language stats look wrong. Takes effect after the change lands on the **default branch**.

--- a/.claude/knowledge/pitfalls/K-PIT-001-node-sass-modern-node.md
+++ b/.claude/knowledge/pitfalls/K-PIT-001-node-sass-modern-node.md
@@ -1,0 +1,29 @@
+# K-PIT-001: node-sass@4 native build fails on modern Node
+
+**Category:** Pitfall
+**Created:** 2026-06-23
+**Tags:** node-sass, sass, node-gyp, install, node-24, native-build, cra
+
+## Context
+Fresh `npm install` on this repo (Node 24) aborted. The toolchain pins `node-sass@4.13.1`, whose native gyp step cannot compile against modern Node/V8.
+
+## Insight
+`node-sass` (libsass) is deprecated and its native bindings only build on the Node version current at its release. On Node 18+ (and hard-fails on 24) `npm install` dies at `node-gyp rebuild` with `Undefined variable standalone_static_library in binding.gyp`.
+
+## Why it matters
+The whole install fails — not just SCSS compilation — so nothing else installs either. Blocks running an otherwise-fine app.
+
+## Symptom
+```
+gyp ERR! configure error
+gyp: Undefined variable standalone_static_library in binding.gyp
+npm error Build failed with error code: 1
+```
+
+## Recovery
+- To just **run** the app when compiled CSS is already committed:
+  `npm install --ignore-scripts` (skips the gyp build; `react-scripts` etc. still land).
+- Permanent fix: replace `node-sass` with Dart **`sass`** (pure JS, no native build) and update the `compile:sass` script, or import SCSS through the bundler.
+
+## Application
+Any repo pinning `node-sass`/`gulp-sass@<5` that won't install on a current Node. First unblock with `--ignore-scripts` if CSS is precommitted; then migrate to `sass`.

--- a/.claude/knowledge/pitfalls/K-PIT-002-react-scripts-openssl.md
+++ b/.claude/knowledge/pitfalls/K-PIT-002-react-scripts-openssl.md
@@ -1,0 +1,24 @@
+# K-PIT-002: react-scripts 3.x won't start on modern Node (OpenSSL)
+
+**Category:** Pitfall
+**Created:** 2026-06-23
+**Tags:** create-react-app, react-scripts, webpack4, openssl, node-17plus
+
+## Context
+After getting deps installed, `npm start` (react-scripts 3.3.0 → webpack 4) needed a flag to boot on Node 24.
+
+## Insight
+Webpack 4's hashing uses an OpenSSL API removed in Node 17+. CRA ≤ 4 crashes with `ERR_OSSL_EVP_UNSUPPORTED` unless you set `NODE_OPTIONS=--openssl-legacy-provider`.
+
+## Why it matters
+Lets you run/verify a legacy CRA app on a current machine without downgrading Node — useful for auditing a project before modernizing it.
+
+## Example
+```bash
+# also: port 3000 was occupied, and CRA opens a browser by default
+HOST=0.0.0.0 BROWSER=none PORT=3055 \
+  NODE_OPTIONS=--openssl-legacy-provider npm start
+```
+
+## Application
+Trigger: `Error: error:0308010C:digital envelope routines::unsupported` from a CRA/webpack-4 project on Node 17+. Add the legacy-provider flag to start/build. Treat it as a stopgap — the real fix is migrating off CRA (Vite/Next).

--- a/.claude/knowledge/pitfalls/K-PIT-003-reputation-framing-in-committed-docs.md
+++ b/.claude/knowledge/pitfalls/K-PIT-003-reputation-framing-in-committed-docs.md
@@ -1,0 +1,23 @@
+# K-PIT-003: Don't bake "reputation" framing or secret-shaped text into committed docs
+
+**Category:** Pitfall
+**Created:** 2026-06-23
+**Tags:** docs, prd, readme, public-repo, privacy, user-feedback
+
+## Context
+Drafted a PRD whose goal was framed as "make this portfolio-grade / worthy of pinning on a GitHub profile / signals craft to recruiters," and CLAUDE.md described the house manual as holding "placeholder secrets (building code, WiFi password)." The user flagged both before committing: a repo meant to be inspected by others must not advertise that its purpose is the author's reputation, nor carry credential-shaped wording.
+
+## Insight
+Committed docs are read by third parties. Keep them about the **product/work**, not the author's career goals, and never describe (even masked) credentials in a way that reads as "secrets live here."
+
+## Why it matters
+Reputation framing undercuts the very credibility it's chasing; credential-shaped text invites scrutiny and can normalize committing real secrets later.
+
+## Symptom
+A grep over committed docs hits: `reputation|recruiter|portfolio|pin.*profile|password|secret|api[_-]?key`.
+
+## Recovery
+Reframe goals around product quality ("production-grade", "correct, well-engineered"). Replace "placeholder secrets (door code, WiFi password)" with "masked placeholders for operational details; real values stay out of the build and out of version control." Re-run the grep until clean.
+
+## Application
+Before committing any README/PRD/CLAUDE.md to a repo others will see, run the reputation+secret grep and scrub. The user prefers this proactively, not after review.


### PR DESCRIPTION
## Summary
- Add `.claude/knowledge/` with a `REGISTRY.md` index and 4 reusable entries captured during the audit/documentation session.

## Entries
- **K-PIT-001** — `node-sass@4` native build aborts `npm install` on modern Node; `--ignore-scripts` to run, migrate to Dart `sass` to fix.
- **K-PIT-002** — `react-scripts` 3.x needs `NODE_OPTIONS=--openssl-legacy-provider` on Node 17+.
- **K-PIT-003** — scrub reputation/credential framing from committed docs before pushing.
- **K-PAT-001** — `.gitattributes` linguist flags to keep generated/vendored files out of GitHub language stats.

## Why
Persist the non-obvious toolchain traps and repo-hygiene patterns from this session so future work (here or elsewhere) starts from them instead of rediscovering.

## Related issue
n/a

## Verification
- [x] no source/behavior changes (docs/knowledge only)
- [x] no secrets / .env files in diff (scan matches are documentation text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)